### PR TITLE
Correct decoding of "dynamic" objects.

### DIFF
--- a/amf_test.go
+++ b/amf_test.go
@@ -108,7 +108,7 @@ func TestAmf0Array(t *testing.T) {
 
 	res, err := EncodeAndDecode(arr, 0)
 	if err != nil {
-		t.Error("amf0 object: %s", err)
+		t.Errorf("amf0 object: %s", err)
 	}
 
 	result, ok := res.(Array)
@@ -170,7 +170,7 @@ func TestAmf3Array(t *testing.T) {
 
 	res, err := EncodeAndDecode(arr, 3)
 	if err != nil {
-		t.Error("amf3 object: %s", err)
+		t.Errorf("amf3 object: %s", err)
 	}
 
 	result, ok := res.(Array)

--- a/decoder_amf3.go
+++ b/decoder_amf3.go
@@ -130,6 +130,10 @@ func (d *Decoder) DecodeAmf3String(r io.Reader, decodeMarker bool) (result strin
 		return
 	}
 
+	if refVal == 0 {
+		return "", nil
+	}
+
 	buf := make([]byte, refVal)
 	_, err = r.Read(buf)
 	if err != nil {

--- a/decoder_amf3_test.go
+++ b/decoder_amf3_test.go
@@ -186,7 +186,7 @@ func TestDecodeAmf3Array(t *testing.T) {
 
 	for i, v := range expect {
 		if got[i] != v {
-			t.Error("expected array element %d to be %v, got %v", i, v, got[i])
+			t.Errorf("expected array element %d to be %v, got %v", i, v, got[i])
 		}
 	}
 }
@@ -211,10 +211,10 @@ func TestDecodeAmf3Object(t *testing.T) {
 	}
 
 	if to["foo"] != "bar" {
-		t.Error("expected foo to be bar, got: %+v", to["foo"])
+		t.Errorf("expected foo to be bar, got: %+v", to["foo"])
 	}
 
 	if to["baz"] != nil {
-		t.Error("expected baz to be nil, got: %+v", to["baz"])
+		t.Errorf("expected baz to be nil, got: %+v", to["baz"])
 	}
 }

--- a/decoder_amf3_test.go
+++ b/decoder_amf3_test.go
@@ -218,3 +218,31 @@ func TestDecodeAmf3Object(t *testing.T) {
 		t.Errorf("expected baz to be nil, got: %+v", to["baz"])
 	}
 }
+
+func TestDecodeAmf3ObjectDynamic(t *testing.T) {
+	buf := bytes.NewReader([]byte{
+		0x0a, 0x0b, 0x01,
+		0x07, 'b', 'a', 'z', 0x01,
+		0x07, 'f', 'o', 'o', 0x06, 0x07, 'b', 'a', 'r',
+		0x01, // terminating empty string
+	})
+
+	dec := new(Decoder)
+	got, err := dec.DecodeAmf3(buf)
+	if err != nil {
+		t.Errorf("err: %s", err)
+	}
+
+	to, ok := got.(Object)
+	if ok != true {
+		t.Error("unable to cast object as typed object")
+	}
+
+	if to["foo"] != "bar" {
+		t.Errorf("expected foo to be bar, got: %+v", to["foo"])
+	}
+
+	if to["baz"] != nil {
+		t.Errorf("expected baz to be nil, got: %+v", to["baz"])
+	}
+}


### PR DESCRIPTION
Dynamic objects end with an empty string. The current code for reading empty strings will fail at the end of a bytes.Reader, which is a typical use case (including unit tests).